### PR TITLE
supply `data` in constructor function

### DIFF
--- a/R/tabulator.R
+++ b/R/tabulator.R
@@ -1,9 +1,9 @@
 #' @import htmlwidgets
 #' @export
-tabulator <- function(message, width = NULL, height = NULL, elementId = NULL) {
+tabulator <- function(data = NULL, width = NULL, height = NULL, elementId = NULL) {
 
   x = list(
-    message = message
+    data = data
   )
 
   ## Add this line to template


### PR DESCRIPTION
https://github.com/ramnathv/htmlwidgets/issues/471

```
library(SOirisIssueTabulator)

tabulator(mtcars)
# appears that . in colnames of iris are causing trouble
tabulator(iris)
iris_no_periods_in_colnames <- iris
colnames(iris_no_periods_in_colnames) <- gsub("\\.", replacement = "_", x = colnames(iris))
tabulator(iris_no_periods_in_colnames)
```